### PR TITLE
Adding --vcfinput flag to pathogenicity

### DIFF
--- a/cwl/tools/annovar_intervar.cwl
+++ b/cwl/tools/annovar_intervar.cwl
@@ -45,5 +45,8 @@ inputs:
     default: true, inputBinding: {position: 2, prefix: "--otherinfo" } }
   threads: { type: 'int?', doc: "Num threads to use to process filter inputs",
     default: 8, inputBinding: { position: 2, prefix: "--thread"} }
+  vcfinput: { type: 'boolean?', doc: "Annotate vcf", default: false,
+    inputBinding: {position: 2, prefix: "--vcfinput" } }  
 outputs:
   annovar_txt: { type: File, outputBinding: { glob: '*_multianno.txt'} }
+  vcf_output: { type: 'File?', outputBinding: { glob: '*.vcf'} }

--- a/cwl/workflows/d3b-diskin-pathogenicity-preprocess-wf.cwl
+++ b/cwl/workflows/d3b-diskin-pathogenicity-preprocess-wf.cwl
@@ -23,6 +23,7 @@ inputs:
   annovar_nastring: { type: 'string?', doc: "character used to represent missing values", default: '.' }
   annovar_otherinfo: { type: 'boolean?', doc: "print out otherinfo (information after fifth column in queryfile)", default: true }
   annovar_threads: { type: 'int?', doc: "Num threads to use to process filter inputs", default: 8 }
+  annovar_vcfinput: { type: 'boolean?', doc: "Annotate vcf and generate output file as vcf", default: false }
   intervar_db: { type: File, doc: "InterVar Database from git repo + mim_genes.txt" }
   intervar_db_str: { type: 'string?', doc: "Name of dir created when intervar db is un-tarred", default: "intervardb" }
   # autoPVS1
@@ -32,7 +33,7 @@ inputs:
 outputs:
   intervar_classification: { type: File, outputSource: run_intervar/intervar_classification}
   autopvs1_tsv: { type: File, outputSource: run_autopvs1/autopvs1_tsv }
-
+  annovar_vcfoutput: { type: 'File?', outputSource: run_intervar/annovar_vcfoutput}
 steps:
   run_intervar:
     run: intervar_classificatiion_wf.cwl
@@ -47,9 +48,10 @@ steps:
         annovar_nastring: annovar_nastring
         annovar_otherinfo: annovar_otherinfo
         annovar_threads: annovar_threads
+        annovar_vcfinput: annovar_vcfinput
         intervar_db: intervar_db
         intervar_db_str: intervar_db_str
-    out: [intervar_classification]
+    out: [intervar_classification, annovar_vcfoutput]
 
   run_autopvs1:
     run: ../tools/autopvs1.cwl

--- a/cwl/workflows/intervar_classificatiion_wf.cwl
+++ b/cwl/workflows/intervar_classificatiion_wf.cwl
@@ -19,10 +19,12 @@ inputs:
   annovar_nastring: { type: 'string?', doc: "character used to represent missing values", default: '.' }
   annovar_otherinfo: { type: 'boolean?', doc: "print out otherinfo (information after fifth column in queryfile)", default: true }
   annovar_threads: { type: 'int?', doc: "Num threads to use to process filter inputs", default: 8 }
+  annovar_vcfinput: { type: 'boolean?', doc: "Annotate vcf and generate output file as vcf", default: false }
   intervar_db: { type: File, doc: "InterVar Database from git repo + mim_genes.txt" }
   intervar_db_str: { type: string, doc: "Name of dir created when intervar db is un-tarred" }
 outputs:
   intervar_classification: { type: File, outputSource: intervar_classify/intervar_scored}
+  annovar_vcfoutput: { type: 'File?', outputSource: run_annovar/vcf_output}
 
 steps:
   convert_to_annovar:
@@ -44,7 +46,8 @@ steps:
       nastring: annovar_nastring
       otherinfo: annovar_otherinfo
       threads: annovar_threads
-    out: [annovar_txt]
+      vcfinput: annovar_vcfinput
+    out: [annovar_txt, vcf_output]
   intervar_classify:
     run: ../tools/intervar.cwl
     in:


### PR DESCRIPTION
[For this ticket](https://app.zenhub.com/workspaces/d3b-bfx-5cdd720eed0dce4209e0b8a5/issues/gh/d3b-center/bixu-tracker/1818) : This PR adds --vcfinput flag to annotate vcf and output it.  

Test runs:

1) https://cavatica.sbgenomics.com/u/d3b-bixu/d3b-diskin-pathogenicity-dev/tasks/1d071b30-3d43-4eac-af85-c0b2b8e0a0c8/
2) https://cavatica.sbgenomics.com/u/d3b-bixu/d3b-diskin-pathogenicity-dev/tasks/2ab3adf9-3f94-4fdb-a32e-2a687e9a9f83/
3) https://cavatica.sbgenomics.com/u/d3b-bixu/d3b-diskin-pathogenicity-dev/tasks/641329d4-2104-4c2f-89c7-6b0a83132c08/
